### PR TITLE
Feature/snakemake simple use case

### DIFF
--- a/simple_use_case/README.md
+++ b/simple_use_case/README.md
@@ -7,7 +7,6 @@ The workflow consists of the following processes:
 * conversion of the file format (into one readable by `dolfin`) using `meshio` (version 4.3.1),
 * solution of the poisson equation using `fenics` (version 2019.1.0),
 * postprocessing using `ParaView` (version 5.9.1),
-* trimming of the resulting PNG file with `ImageMagick` (version 6.9.10-23),
 * and finally generation of a PDF using `Latex` (version 3.141592653-2.6-1.40.23 (TeX Live 2021)).
 
 Compute environment

--- a/simple_use_case/snakemake/.gitignore
+++ b/simple_use_case/snakemake/.gitignore
@@ -1,0 +1,4 @@
+.snakemake
+preprocessing/
+processing/
+postprocessing/

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -1,9 +1,7 @@
-Snakemake
-=========
+# Snakemake
 Some notes on my user/learning experience with snakemake.
 
-Paper
------
+## Paper
 * improved readability due to domain specific language (DSL) (+) (*transparency*, *adaptability*); assumption: for user with no prior knowledge it is easier to learn/understand DSL instead of programming language
 * DSL obviates superfluous operators or boilerplate code (+, example?)
 * includes deployment of software stack (conda env that is automatically installed; singularity or docker containers) (++) (*portability*)
@@ -18,8 +16,7 @@ Paper
 * arbitrary python code can be used to define task metadata, but for certain use cases (presumably typical processes in data analysis) Snakemake explicitly defines directives to be used (see section 3.2 scatter/gather processes)
 
 
-Tutorial
---------
+## Tutorial
 * Snakemake wants to re-run the job after changes to the file modification date (-):
 ```
 touch data/samples/A.fastq
@@ -43,8 +40,7 @@ Isn't this contradictory to section 2.5.2 "Caching between workflows" in the sna
 * only input files (not output!) can be specified as functions
 
 
-Wildcards
----------
+### Wildcards
 ```
 snakemake -np mapped_reads/B.bam
 ```
@@ -52,3 +48,18 @@ defines the output file `mapped_reads/B.bam` for a job generated from rule `bwa_
 The wildcard `{sample}` is filled in with the value `B` given in the command.
 This value is then propagated to find and check for appropriate input files (and not the other way around, like a file pattern matching ...).
 * What is the point of using an input function if in the output file definition a wildcard is used?
+
+
+## Test case implementation
+In contrast to the `pydoit` implementation, the single conda environment is split in several environments since with `snakemake` it is possible to specify a conda environment for each rule. 
+This has the benefit of modularization and later on the option to automatically write a Dockerfile (`--containerize`).
+At the time of writing there is however a bug which is fixed but the PR not included in the latest version (6.10.0) of snakemake.
+
+### Execution
+```
+snakemake --cores 1 --use-conda postprocessing/paper.pdf
+```
+The number of cores always needs to be specified. `--use-conda` is False by default.
+Other useful options are `--dryrun, -n` for a dry-run and `--prindshellcmds, -p` to print out shell commands that will be executed.
+For more help `snakemake --help` of course.
+The current Snakefile implementation requires the user to explicitly define the target `postprocessing/paper.pdf` such that an appropriate job can be generated from the rule `compile`.

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -64,6 +64,15 @@ Other useful options are `--dryrun, -n` for a dry-run and `--printshellcmds, -p`
 The current Snakefile implementation requires the user to explicitly define the target `postprocessing/paper.pdf` such that an appropriate job can be generated from the rule `compile`.
 
 ### Provenance graph
+Exporting the DAG requires `graphviz` to be installed.
 ```
 snakemake --dag postprocessing/paper.pdf | dot -Tsvg > dag.svg
 ```
+
+## Problems
+* running the workflow at home, I got the following error when trying to run `poisson.py`
+```
+ImportError: libsuperlu_dist.so.6: cannot open shared object file: No such file or directory
+```
+Somehow, building the conda env from `envs/processing.yaml` does not find superlu? although it seems to be there when inspecting
+`.snakemake/conda/<some-hash>` where conda envs are installed. Additionally specifying `python=3.7` solves the problem (`python=3.7.12`, `superlu=5.2.2` and `superlu_dist=6.2.0` are installed in contrast to `python=3.9.7`,`superlu=5.2.2` and `superlu_dist=7.1.1` whithout python specification).

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -70,9 +70,26 @@ snakemake --dag postprocessing/paper.pdf | dot -Tsvg > dag.svg
 ```
 
 ## Problems
-* running the workflow at home, I got the following error when trying to run `poisson.py`
+
+### Processing Env
+Running the workflow at home, I got the following error when trying to run `poisson.py`
 ```
 ImportError: libsuperlu_dist.so.6: cannot open shared object file: No such file or directory
 ```
 Somehow, building the conda env from `envs/processing.yaml` does not find superlu? although it seems to be there when inspecting
 `.snakemake/conda/<some-hash>` where conda envs are installed. Additionally specifying `python=3.7` solves the problem (`python=3.7.12`, `superlu=5.2.2` and `superlu_dist=6.2.0` are installed in contrast to `python=3.9.7`,`superlu=5.2.2` and `superlu_dist=7.1.1` whithout python specification).
+
+### Debugging
+From the snakemake help:
+```
+  --debug-dag           Print candidate and selected jobs (including their
+                        wildcards) while inferring DAG. This can help to debug
+                        unexpected DAG topology or errors. (default: False)
+  --verbose             Print debugging output. (default: False)
+  --overwrite-shellcmd OVERWRITE_SHELLCMD
+                        Provide a shell command that shall be executed instead
+                        of those given in the workflow. This is for debugging
+                        purposes only. (default: None)
+  --debug		Allow to debug rules with e.g. PDB. This flag allows
+			to set breakpoints in run blocks. (default: False)
+```

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -62,3 +62,8 @@ snakemake --cores 1 --use-conda postprocessing/paper.pdf
 The number of cores always needs to be specified. `--use-conda` is False by default.
 Other useful options are `--dryrun, -n` for a dry-run and `--printshellcmds, -p` to print out shell commands that will be executed.  For more help `snakemake --help` of course.
 The current Snakefile implementation requires the user to explicitly define the target `postprocessing/paper.pdf` such that an appropriate job can be generated from the rule `compile`.
+
+### Provenance graph
+```
+snakemake --dag postprocessing/paper.pdf | dot -Tsvg > dag.svg
+```

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -56,6 +56,7 @@ This has the benefit of modularization and later on the option to automatically 
 At the time of writing there is however a [bug](https://github.com/snakemake/snakemake/issues/1210) which is fixed but the PR not included in the latest version (6.10.0) of snakemake.
 
 ### Execution
+Only requirement is the [installation](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html) of `snakemake=6.10.0`. The workflow can be executed with
 ```
 snakemake --cores 1 --use-conda postprocessing/paper.pdf
 ```

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -1,0 +1,54 @@
+Snakemake
+=========
+Some notes on my user/learning experience with snakemake.
+
+Paper
+-----
+* improved readability due to domain specific language (DSL) (+) (*transparency*, *adaptability*); assumption: for user with no prior knowledge it is easier to learn/understand DSL instead of programming language
+* DSL obviates superfluous operators or boilerplate code (+, example?)
+* includes deployment of software stack (conda env that is automatically installed; singularity or docker containers) (++) (*portability*)
+* automatic containerization; Dockerfile that deploys all defined conda environments into the container (+); size problem with this container?
+* parallel execution of the workflow is easy (+) (*scalability-parallelism*)
+* how do I execute a snakemake workflow on a HPC machine? (*scalability-platform*)
+* directed acyclic graph (DAG) is obtained by snakemake and can be visualized easily (+)
+* automated unit test generation (?)
+* automatically generated interactive reports (+)
+* inclusion of other Snakefiles and workflow composition
+* integration of scripts and jupyter notebooks as well as use of tool wrappers which can be shared via a central public repository (++); usually tools provide one of the two, but having both seems like a big advantage
+* arbitrary python code can be used to define task metadata, but for certain use cases (presumably typical processes in data analysis) Snakemake explicitly defines directives to be used (see section 3.2 scatter/gather processes)
+
+
+Tutorial
+--------
+* Snakemake wants to re-run the job after changes to the file modification date (-):
+```
+touch data/samples/A.fastq
+```
+The job is re-run although the file's contents did not change.
+(With `pydoit` this is not the case.)
+Isn't this contradictory to section 2.5.2 "Caching between workflows" in the snakemake paper? No, first check if outputfile with certain hash value exists in the cache. If it exists, check whether one of the inputs is newer and re-run if this is the case.
+
+* snakemake automatically creates missing directories (+)
+* when executing a the workflow one does not specify the name of the rule, but the name of the target. Hence, one can run the same workflow using different targets. This is different to e.g. pydoit, but does not make a big difference. (Think of wildcards as task generators)
+* script integration: boilerplate code like parsing of CL arguments in the python script becomes unnecessary (+); this is in contrast to python script execution like `python <script.py> [options] A B`; however, this makes the script specific to the tool snakemake, I could not use the same script in another workflow tool (-); this also requires the user to use snakemake from the beginning
+* Apart from filenames, Snakemake also accepts rule names as targets if the requested rule does not have wildcards.
+* if no target is given at the command line, Snakemake will define the first rule of the Snakefile as the target
+* How can I debug the Snakefile?
+* Dependencies are on targets? (not on tasks?)
+* configuration files in JSON or YAML format for customization of workflows
+* using `config["samples"]` (dict) instead of `SAMPLES` (list) in rule *bcftools_call* confuses me
+* How can I show info about some rule using the CLI? E.g. show all input files for rule xy?
+* Step 3 of the Advanced Tutorial is unclear: normally I can use wildcards for input file definition, but not when a configuration file is used?
+* expand functions are executed during initialization phase; input functions are executed during DAG phase ...
+* only input files (not output!) can be specified as functions
+
+
+Wildcards
+---------
+```
+snakemake -np mapped_reads/B.bam
+```
+defines the output file `mapped_reads/B.bam` for a job generated from rule `bwa_map`. 
+The wildcard `{sample}` is filled in with the value `B` given in the command.
+This value is then propagated to find and check for appropriate input files (and not the other way around, like a file pattern matching ...).
+* What is the point of using an input function if in the output file definition a wildcard is used?

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -53,7 +53,7 @@ This value is then propagated to find and check for appropriate input files (and
 ## Test case implementation
 In contrast to the `pydoit` implementation, the single conda environment is split in several environments since with `snakemake` it is possible to specify a conda environment for each rule. 
 This has the benefit of modularization and later on the option to automatically write a Dockerfile (`--containerize`).
-At the time of writing there is however a bug which is fixed but the PR not included in the latest version (6.10.0) of snakemake.
+At the time of writing there is however a [bug](https://github.com/snakemake/snakemake/issues/1210) which is fixed but the PR not included in the latest version (6.10.0) of snakemake.
 
 ### Execution
 ```

--- a/simple_use_case/snakemake/README.md
+++ b/simple_use_case/snakemake/README.md
@@ -60,6 +60,5 @@ At the time of writing there is however a [bug](https://github.com/snakemake/sna
 snakemake --cores 1 --use-conda postprocessing/paper.pdf
 ```
 The number of cores always needs to be specified. `--use-conda` is False by default.
-Other useful options are `--dryrun, -n` for a dry-run and `--prindshellcmds, -p` to print out shell commands that will be executed.
-For more help `snakemake --help` of course.
+Other useful options are `--dryrun, -n` for a dry-run and `--printshellcmds, -p` to print out shell commands that will be executed.  For more help `snakemake --help` of course.
 The current Snakefile implementation requires the user to explicitly define the target `postprocessing/paper.pdf` such that an appropriate job can be generated from the rule `compile`.

--- a/simple_use_case/snakemake/Snakefile
+++ b/simple_use_case/snakemake/Snakefile
@@ -1,0 +1,65 @@
+rule generate_mesh:
+	input:
+		"../source/unit_square.geo"
+	output:
+		"preprocessing/unit_square.msh"
+	conda:
+		"envs/preprocessing.yaml"
+	shell:
+		"gmsh -2 -order 1 -format msh2 {input} -o {output}"
+
+
+rule convert_to_xdmf:
+	input:
+		"preprocessing/{domain}.msh"
+	output:
+		"preprocessing/{domain}.xdmf"
+	conda:
+		"envs/preprocessing.yaml"
+	shell:
+		"meshio-convert {input} {output}"
+
+
+rule poisson:
+	input:
+		py="../source/poisson.py",
+		xdmf="preprocessing/unit_square.xdmf"
+	output:
+		"processing/poisson.pvd"
+	conda:
+		"envs/processing.yaml"
+	shell:
+		"python {input.py} --mesh {input.xdmf} --degree 2 --outputfile {output}"
+
+
+rule plot_solution:
+	input:
+		py="../source/postprocessing.py",
+		pvd="processing/poisson.pvd"
+	output:
+		"postprocessing/contourplot.png"
+	conda:
+		"envs/postprocessing.yaml"
+	shell:
+		"pvbatch {input.py} {input.pvd} {output}"
+
+
+rule copy_source:
+	input:
+		"../source/{document}.tex"
+	output:
+		"postprocessing/{document}.tex"
+	shell:
+		"cp {input} {output}"
+
+
+rule compile:
+	input:
+		tex="postprocessing/{document}.tex",
+		png="postprocessing/contourplot.png"
+	output:
+		"postprocessing/{document}.pdf"
+	conda:
+		"envs/postprocessing.yaml"
+	shell:
+		"tectonic {input.tex}"

--- a/simple_use_case/snakemake/envs/postprocessing.yaml
+++ b/simple_use_case/snakemake/envs/postprocessing.yaml
@@ -1,0 +1,5 @@
+channels:
+        - conda-forge
+dependencies:
+        - paraview=5.9.1
+        - tectonic=0.8.0

--- a/simple_use_case/snakemake/envs/preprocessing.yaml
+++ b/simple_use_case/snakemake/envs/preprocessing.yaml
@@ -1,0 +1,5 @@
+channels:
+        - conda-forge
+dependencies:
+        - gmsh=4.6.0
+        - meshio=4.3.1

--- a/simple_use_case/snakemake/envs/processing.yaml
+++ b/simple_use_case/snakemake/envs/processing.yaml
@@ -1,4 +1,5 @@
 channels:
         - conda-forge
 dependencies:
+        - python=3.7
         - fenics=2019.1.0

--- a/simple_use_case/snakemake/envs/processing.yaml
+++ b/simple_use_case/snakemake/envs/processing.yaml
@@ -1,0 +1,4 @@
+channels:
+        - conda-forge
+dependencies:
+        - fenics=2019.1.0


### PR DESCRIPTION
Hi @dglaeser , Hi @joergfunger ,
I implemented the simple use case with snakemake. I am making use of snakemake's ability to use conda to deploy the software stack. Therefore, there are three different conda environments for the preprocessing (generate mesh and convert to xdmf), processing (run fenics code) and postprocessing (paraview plot and PDF compilation using [tectonic](https://tectonic-typesetting.github.io/en-US/)). 
I took some notes in the README to document my experience with snakemake.