### PR TITLE
Feature/nextflow simplecase

### DIFF
--- a/simple_use_case/nextflow/.gitignore
+++ b/simple_use_case/nextflow/.gitignore
@@ -1,0 +1,4 @@
+work
+.nextflow
+.nextflow.log*
+tutorial.nf

--- a/simple_use_case/nextflow/README.md
+++ b/simple_use_case/nextflow/README.md
@@ -1,0 +1,3 @@
+Nextflow
+--------
+Some notes about [nextflow](https://nextflow.io/). The documentation is available under [this link](https://www.nextflow.io/docs/latest/index.html).

--- a/simple_use_case/nextflow/README.md
+++ b/simple_use_case/nextflow/README.md
@@ -33,5 +33,8 @@ Di Tommaso et Al.
 
 Simple use case
 ---------------
+```
+nextflow run simplecase.nf
+```
 * pipeline results are cached by default in the directory `$PWD/work`. Each process is executed again unless one adds the option `-resume`. In this case the results are retrieved from the cache. [Modify and resume](https://www.nextflow.io/docs/latest/getstarted.html#modify-and-resume)
 * for each process a directory named after the process ID will be created. Here the input and output files are stored (using symlinks to avoid duplication). There are also hidden files which give information about the process execution (`.command.<name>` were `<name>` is one of the following `begin`, `err`, `log`, `out`, `run`, `sh`)

--- a/simple_use_case/nextflow/README.md
+++ b/simple_use_case/nextflow/README.md
@@ -1,3 +1,32 @@
 Nextflow
---------
+========
 Some notes about [nextflow](https://nextflow.io/). The documentation is available under [this link](https://www.nextflow.io/docs/latest/index.html).
+
+Wratten et Al.
+--------------
+* domain specific language (DSL) based on the groovy programming language
+* steps of a pipeline split into modular components and connected through channels that determine pipeline execution (dataflow paradigm)
+* ability to create reusable modules for steps of the workflow
+* active community with a large number of published ready-to-use pipelines (refs. 63-66)
+* nf-core project: community-curated pipelines; framework to host nextflow pipelines, which requires best practices and sets standards for pipeline implementations to guarantee their maintenance, documentation, portability, scalability, and reproducibility
+* curated pipelines are citable (often with Zenodo DOI) 
+
+Di Tommaso et Al.
+-----------------
+* sources of irreproducibility: lack of good practice pertaining to software and database usage, variations across computational platforms
+* nextflow uses Docker technology for the multi-scale handling of containerized computation
+* another challenge: handling a large number of software packages and conflicting requirements of frequent software updates and maintaining the reproducibility of original results
+* high-throughput: how to deal with intermediate files?
+* nextflow is designed to address numerical instability, efficient parallel execution, error tolerance, execution provenance and traceability
+* existing pipelines written in any scripting language
+* multi-scale containerization, which makes it possible to bundle entire pipelines, subcomponents and individual tools into their own containers, is essential for numerical stability
+* containers can be produced *ad hoc* by users or by following recently proposed standards (BioBoxes, Bioshadock and AlgoRun)
+* integration with software repositories (GitHub, BitBucket)
+* native support for cloud systems
+* consequence of the prior 2 points: ability to run any current or previous version of a pipeline/workflow
+* nextflow relies on the dataflow programming paradigm, which, according to the authors, is superior to alternative solutions based on a Make-like approach (such as Snakemake, pyDoit, ...)
+* Make-like procedure requires a DAG while nextflow does not ("top to bottom processing model follows the natural flow of data")
+* unclear: how does nextflow determine which processes are not uptodate? skip certain tasks?
+* outputs are not limited to files but can also include in-memory values and data objects
+* example genomic analysis: differences in "native" workflow execution and containerization as solution; what is the truth? docker image is also based on some operating system ...
+* table 1 is not up to date (by now Snakemake supports Docker)

--- a/simple_use_case/nextflow/README.md
+++ b/simple_use_case/nextflow/README.md
@@ -38,3 +38,4 @@ nextflow run simplecase.nf
 ```
 * pipeline results are cached by default in the directory `$PWD/work`. Each process is executed again unless one adds the option `-resume`. In this case the results are retrieved from the cache. [Modify and resume](https://www.nextflow.io/docs/latest/getstarted.html#modify-and-resume)
 * for each process a directory named after the process ID will be created. Here the input and output files are stored (using symlinks to avoid duplication). There are also hidden files which give information about the process execution (`.command.<name>` were `<name>` is one of the following `begin`, `err`, `log`, `out`, `run`, `sh`)
+* when using the conda directive with environment files the conda env is created at `$PWD/work/conda/<env-name>-<some-hash>`

--- a/simple_use_case/nextflow/README.md
+++ b/simple_use_case/nextflow/README.md
@@ -30,3 +30,8 @@ Di Tommaso et Al.
 * outputs are not limited to files but can also include in-memory values and data objects
 * example genomic analysis: differences in "native" workflow execution and containerization as solution; what is the truth? docker image is also based on some operating system ...
 * table 1 is not up to date (by now Snakemake supports Docker)
+
+Simple use case
+---------------
+* pipeline results are cached by default in the directory `$PWD/work`. Each process is executed again unless one adds the option `-resume`. In this case the results are retrieved from the cache. [Modify and resume](https://www.nextflow.io/docs/latest/getstarted.html#modify-and-resume)
+* for each process a directory named after the process ID will be created. Here the input and output files are stored (using symlinks to avoid duplication). There are also hidden files which give information about the process execution (`.command.<name>` were `<name>` is one of the following `begin`, `err`, `log`, `out`, `run`, `sh`)

--- a/simple_use_case/nextflow/envs/postprocessing.yaml
+++ b/simple_use_case/nextflow/envs/postprocessing.yaml
@@ -1,0 +1,5 @@
+channels:
+        - conda-forge
+dependencies:
+        - paraview=5.9.1
+        - tectonic=0.8.0

--- a/simple_use_case/nextflow/envs/preprocessing.yaml
+++ b/simple_use_case/nextflow/envs/preprocessing.yaml
@@ -1,0 +1,5 @@
+channels:
+        - conda-forge
+dependencies:
+        - gmsh=4.6.0
+        - meshio=4.3.1

--- a/simple_use_case/nextflow/envs/processing.yaml
+++ b/simple_use_case/nextflow/envs/processing.yaml
@@ -1,0 +1,5 @@
+channels:
+        - conda-forge
+dependencies:
+        - python=3.7
+        - fenics=2019.1.0

--- a/simple_use_case/nextflow/simplecase.nf
+++ b/simple_use_case/nextflow/simplecase.nf
@@ -1,0 +1,97 @@
+#!/usr/bin/env nextflow
+
+params.degree = 2
+
+// for now simply add dependent files as Channels
+geo_ch = Channel.fromPath("$PWD/../source/unit_square.geo")
+fenics_ch = Channel.fromPath("$PWD/../source/poisson.py")
+pv_ch = Channel.fromPath("$PWD/../source/postprocessing.py")
+tex_ch = Channel.fromPath("$PWD/../source/paper.tex")
+
+process generateMesh {
+    // generate mesh using Gmsh
+
+    // use conda directive to specify existing environment
+    conda "$HOME/miniconda3/envs/multi"
+
+    input:
+    file geo from geo_ch
+
+    output:
+    file 'unit_square.msh' into msh_ch
+
+    """
+    gmsh -2 -order 1 -format msh2 $geo -o unit_square.msh
+    """
+}
+
+
+process convertToXDMF {
+    // convert any msh file to xdmf
+
+    conda "$HOME/miniconda3/envs/multi"
+
+    input:
+    file msh from msh_ch
+
+    output:
+    file 'unit_square.h5' into h5_ch
+    file 'unit_square.xdmf' into xdmf_ch
+
+    """
+    meshio-convert $msh unit_square.xdmf
+    """
+}
+
+
+process solvePoisson {
+    // solve poisson equation using fenics code
+
+    conda "$HOME/miniconda3/envs/multi"
+
+    // multiple inputs from different channels
+    input:
+    file fenics_code from fenics_ch
+    file meshdata from h5_ch
+    file mesh from xdmf_ch
+
+    output:
+    file 'poisson.pvd' into pvd_ch
+    file 'poisson*.vtu' into vtu_ch
+
+    """
+    python $fenics_code --mesh $mesh --degree ${params.degree} --outputfile poisson.pvd
+    """
+}
+
+
+process makeContourplot {
+    input:
+    file postproc from pv_ch
+    file vtu from vtu_ch
+    file pvd from pvd_ch
+
+    output: 
+    file 'contourplot.png' into png_ch
+
+    """
+    pvbatch $postproc $pvd contourplot.png
+    """
+}
+
+
+process compile {
+
+    conda "$HOME/miniconda3/envs/tectonic"
+
+    input:
+    file tex_code from tex_ch
+    file png from png_ch
+
+    output:
+    file 'paper.pdf' 
+
+    """
+    tectonic $tex_code
+    """
+}

--- a/simple_use_case/nextflow/simplecase.nf
+++ b/simple_use_case/nextflow/simplecase.nf
@@ -11,8 +11,8 @@ tex_ch = Channel.fromPath("$PWD/../source/paper.tex")
 process generateMesh {
     // generate mesh using Gmsh
 
-    // use conda directive to specify existing environment
-    conda "$HOME/miniconda3/envs/multi"
+    // use conda directive to specify environment file
+    conda "./envs/preprocessing.yaml"
 
     input:
     file geo from geo_ch
@@ -29,7 +29,7 @@ process generateMesh {
 process convertToXDMF {
     // convert any msh file to xdmf
 
-    conda "$HOME/miniconda3/envs/multi"
+    conda "./envs/preprocessing.yaml"
 
     input:
     file msh from msh_ch
@@ -47,7 +47,7 @@ process convertToXDMF {
 process solvePoisson {
     // solve poisson equation using fenics code
 
-    conda "$HOME/miniconda3/envs/multi"
+    conda "./envs/processing.yaml"
 
     // multiple inputs from different channels
     input:
@@ -66,6 +66,9 @@ process solvePoisson {
 
 
 process makeContourplot {
+
+    conda "./envs/postprocessing.yaml"
+
     input:
     file postproc from pv_ch
     file vtu from vtu_ch
@@ -82,7 +85,7 @@ process makeContourplot {
 
 process compile {
 
-    conda "$HOME/miniconda3/envs/tectonic"
+    conda "./envs/postprocessing.yaml"
 
     input:
     file tex_code from tex_ch


### PR DESCRIPTION
Hi @dglaeser , Hi @joergfunger ,
this is the current version of the simple use case implemented in nextflow. I am making use of nextflow's ability to build the conda environment similar to snakemake. The same environment files under `envs` are used until we decide how to handle this in general...
The current implementation is very basic in the sense that it is not very flexible (hardcoded filenames). For example, for the process `convertToXDMF` to be reusable in other workflows it would be nice if input and output could be any msh, xdmf file respectively. This is still work in progress.