### PR TITLE
Feature/simplify cwl

### DIFF
--- a/simple_use_case/cwl/README.md
+++ b/simple_use_case/cwl/README.md
@@ -19,3 +19,8 @@ cwltool wf_run_use_case.cwl
 ```
 
 into your terminal.
+
+Note that there exist tools to visualize, edit or create cwl workflows. For instance, you can
+visualize workflows contained in git repositories with [view.commonwl.org](https://view.commonwl.org/),
+or you can use the [Rabix Composer](https://github.com/rabix/composer) to compose workflows locally
+on your machine.

--- a/simple_use_case/cwl/compile_paper.cwl
+++ b/simple_use_case/cwl/compile_paper.cwl
@@ -16,6 +16,9 @@ inputs:
     type: File
   texfile:
     type: File
+    default:
+      class: File
+      location: ../source/paper.tex
 outputs:
   pdf:
     type: File

--- a/simple_use_case/cwl/compile_paper.cwl
+++ b/simple_use_case/cwl/compile_paper.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 doc: |
-  Create the paper as pdf, given the correct images
+  Create the paper as pdf, given the produced csv file
 baseCommand: ["tectonic"]
 arguments: ["$(inputs.texfile)"]
 requirements:

--- a/simple_use_case/cwl/convert_msh_to_xdmf.cwl
+++ b/simple_use_case/cwl/convert_msh_to_xdmf.cwl
@@ -5,18 +5,16 @@ class: CommandLineTool
 doc: |
   Convert gmsh mesh file format to xdmf
 baseCommand: ["meshio", "convert"]
-arguments: ["$(inputs.inputmesh.path)", "$(inputs.outfilename).xdmf"]
+arguments: ["$(inputs.inputmesh.path)", "mesh_converted.xdmf"]
 inputs:
   inputmesh:
     type: File
-  outfilename:
-    type: string
 outputs:
   outputmesh:
     type: File
     outputBinding:
-      glob: $(inputs.outfilename).xdmf
+      glob: "mesh_converted.xdmf"
   outputmeshdata:
     type: File
     outputBinding:
-       glob: $(inputs.outfilename).h5
+       glob: "mesh_converted.h5"

--- a/simple_use_case/cwl/convert_msh_to_xdmf.cwl
+++ b/simple_use_case/cwl/convert_msh_to_xdmf.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 doc: |
-  Convert gmsh mesh file format to xdmf
+  Convert the produced gmsh mesh to xdmf
 baseCommand: ["meshio", "convert"]
 arguments: ["$(inputs.inputmesh.path)", "mesh_converted.xdmf"]
 inputs:

--- a/simple_use_case/cwl/make_gmsh_mesh.cwl
+++ b/simple_use_case/cwl/make_gmsh_mesh.cwl
@@ -5,16 +5,13 @@ class: CommandLineTool
 doc: |
   mesh generation with gmsh
 baseCommand: ["gmsh"]
-arguments: ["-2", "$(inputs.geofile.path)", "-o", "$(inputs.outfilename)"]
+arguments: ["-2", "$(inputs.geofile.path)", "-o", "mesh.msh"]
 inputs:
   geofile:
     type: File
     doc: "Geometry file in a gmsh-readable format"
-  outfilename:
-    type: string
-    doc: "The name of the mesh file to be written, including the desired extension"
 outputs:
   mesh:
     type: File
     outputBinding:
-      glob: $(inputs.outfilename)
+      glob: "mesh.msh"

--- a/simple_use_case/cwl/make_gmsh_mesh.cwl
+++ b/simple_use_case/cwl/make_gmsh_mesh.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 doc: |
-  mesh generation with gmsh
+  Generate the computational mesh with gmsh
 baseCommand: ["gmsh"]
 arguments: ["-2", "$(inputs.geofile.path)", "-o", "mesh.msh"]
 inputs:

--- a/simple_use_case/cwl/make_gmsh_mesh.cwl
+++ b/simple_use_case/cwl/make_gmsh_mesh.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 doc: |
   mesh generation with gmsh
 baseCommand: ["gmsh"]
-arguments: ["-$(inputs.dimension)", "$(inputs.geofile.path)", "-o", "$(inputs.outfilename)"]
+arguments: ["-2", "$(inputs.geofile.path)", "-o", "$(inputs.outfilename)"]
 inputs:
   geofile:
     type: File
@@ -13,9 +13,6 @@ inputs:
   outfilename:
     type: string
     doc: "The name of the mesh file to be written, including the desired extension"
-  dimension:
-    type: int
-    doc: "The desired dimension of the mesh"
 outputs:
   mesh:
     type: File

--- a/simple_use_case/cwl/make_paraview_plot.cwl
+++ b/simple_use_case/cwl/make_paraview_plot.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 doc: |
-  Create rendering from vtk file using pvbatch
+  Create plot-over-line data with paraview`s pvbatch
 baseCommand: ["pvbatch"]
 arguments: ["$(inputs.script)", "$(inputs.pvdfile.path)", "plotoverline.csv"]
 requirements:

--- a/simple_use_case/cwl/make_paraview_plot.cwl
+++ b/simple_use_case/cwl/make_paraview_plot.cwl
@@ -5,7 +5,7 @@ class: CommandLineTool
 doc: |
   Create rendering from vtk file using pvbatch
 baseCommand: ["pvbatch"]
-arguments: ["$(inputs.script)", "$(inputs.pvdfile.path)", "$(inputs.outputfile)"]
+arguments: ["$(inputs.script)", "$(inputs.pvdfile.path)", "plotoverline.csv"]
 requirements:
   InitialWorkDirRequirement:
       listing:
@@ -21,10 +21,8 @@ inputs:
     type: File
   pvdfile:
     type: File
-  outputfile:
-    type: string
 outputs:
   resultcsv:
     type: File
     outputBinding:
-      glob: $(inputs.outputfile)
+      glob: "plotoverline.csv"

--- a/simple_use_case/cwl/make_paraview_plot.cwl
+++ b/simple_use_case/cwl/make_paraview_plot.cwl
@@ -14,6 +14,9 @@ requirements:
 inputs:
   script:
     type: File
+    default:
+      class: File
+      location: ../source/postprocessing.py
   vtkfile:
     type: File
   pvdfile:

--- a/simple_use_case/cwl/run_dolfin.cwl
+++ b/simple_use_case/cwl/run_dolfin.cwl
@@ -16,6 +16,9 @@ requirements:
 inputs:
   script:
     type: File
+    default:
+      class: File
+      location: ../source/poisson.py
   xdmfmeshfile:
     type: File
   h5meshfile:

--- a/simple_use_case/cwl/run_dolfin.cwl
+++ b/simple_use_case/cwl/run_dolfin.cwl
@@ -3,7 +3,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 doc: |
-  poisson solver with dolfin
+  Run the poisson solver in dolfin
 baseCommand: ["python3"]
 arguments: ["$(inputs.script)", "--mesh", "$(inputs.xdmfmeshfile.path)",
                                 "--degree", "2",

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -26,11 +26,6 @@ inputs:
     default:
       class: File
       location: ../source/unit_square.geo
-  pvbatchscript:
-    type: File
-    default:
-      class: File
-      location: ../source/postprocessing.py
 
 steps:
 
@@ -56,7 +51,6 @@ steps:
   plot_over_line:
     run: make_paraview_plot.cwl
     in:
-      script: pvbatchscript
       vtkfile: run_simulation/resultvtu
       pvdfile: run_simulation/resultpvd
       outputfile:

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -42,8 +42,6 @@ steps:
   make_mesh:
     run: make_gmsh_mesh.cwl
     in:
-      dimension:
-        default: 2
       geofile: geometryfile
       outfilename:
         default: "unit_square.msh"

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -4,18 +4,6 @@ cwlVersion: v1.0
 class: Workflow
 
 outputs:
-  mesh:
-    type: File
-    outputSource: make_mesh/mesh
-  resultvtu:
-    type: File
-    outputSource: run_simulation/resultvtu
-  resultpvd:
-    type: File
-    outputSource: run_simulation/resultpvd
-  resultimage:
-    type: File
-    outputSource: plot_over_line/resultcsv
   paperpdf:
     type: File
     outputSource: compile_paper/pdf

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -49,8 +49,6 @@ steps:
     run: convert_msh_to_xdmf.cwl
     in:
       inputmesh: make_mesh/mesh
-      outfilename:
-        default: "unit_square"
     out: [outputmesh, outputmeshdata]
 
   run_simulation:

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -41,8 +41,6 @@ steps:
     in:
       vtkfile: run_simulation/resultvtu
       pvdfile: run_simulation/resultpvd
-      outputfile:
-        default: "plotoverline.csv"
     out: [resultcsv]
 
   compile_paper:

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -36,11 +36,6 @@ inputs:
     default:
       class: File
       location: ../source/postprocessing.py
-  papersource:
-    type: File
-    default:
-      class: File
-      location: ../source/paper.tex
 
 steps:
 
@@ -84,5 +79,4 @@ steps:
     run: compile_paper.cwl
     in:
       csvfile: plot_over_line/resultcsv
-      texfile: papersource
     out: [pdf]

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -26,11 +26,6 @@ inputs:
     default:
       class: File
       location: ../source/unit_square.geo
-  dolfinscript:
-    type: File
-    default:
-      class: File
-      location: ../source/poisson.py
   pvbatchscript:
     type: File
     default:
@@ -54,7 +49,6 @@ steps:
   run_simulation:
     run: run_dolfin.cwl
     in:
-      script: dolfinscript
       xdmfmeshfile: convert_mesh/outputmesh
       h5meshfile: convert_mesh/outputmeshdata
     out: [resultvtu, resultpvd]

--- a/simple_use_case/cwl/wf_run_use_case.cwl
+++ b/simple_use_case/cwl/wf_run_use_case.cwl
@@ -43,8 +43,6 @@ steps:
     run: make_gmsh_mesh.cwl
     in:
       geofile: geometryfile
-      outfilename:
-        default: "unit_square.msh"
     out: [mesh]
 
   convert_mesh:


### PR DESCRIPTION
@joergfunger, this simplifies the cwl workflow to now only expose the geometry file as input, producing the paper at the end. This makes this simple use case easier to understand as the workflow file now looks cleaner and is smaller. The visualization now looks like this: https://view.commonwl.org/workflows/github.com/BAMresearch/NFDI4IngScientificWorkflowRequirements/blob/feature/simplify-cwl/simple_use_case/cwl/wf_run_use_case.cwl

NOTE: This builds upon on #21, which should be merged first. The actual commit history of this branch starts with 4c6d6880ee90f7c0e1f11e18e12eec1a5a7d3055