### PR TITLE
Fix/nextflow output path

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -4,9 +4,10 @@ import pathlib
 def task_website():
     deps = ["index.rst", "conf.py"]
     docs = pathlib.Path("docs")
-    sources = list(docs.glob("*.rst"))
+    for f in docs.glob("*.rst"):
+        deps.append(str(f))
     return {
-            "file_dep": deps + sources,
-            "actions": ["sphinx-build . website"],
-            "verbosity": 2,
-            }
+        "file_dep": deps,
+        "actions": ["sphinx-build . website"],
+        "verbosity": 2,
+    }

--- a/simple_use_case/nextflow/.gitignore
+++ b/simple_use_case/nextflow/.gitignore
@@ -1,4 +1,5 @@
 work
+paper.pdf
 .nextflow
 .nextflow.log*
 tutorial.nf

--- a/simple_use_case/nextflow/simplecase.nf
+++ b/simple_use_case/nextflow/simplecase.nf
@@ -18,7 +18,7 @@ process generateMesh {
     file geo from geo_ch
 
     output:
-    file 'unit_square.msh' into msh_ch
+    file "unit_square.msh" into msh_ch
 
     """
     gmsh -2 -order 1 -format msh2 $geo -o unit_square.msh
@@ -35,8 +35,8 @@ process convertToXDMF {
     file msh from msh_ch
 
     output:
-    file 'unit_square.h5' into h5_ch
-    file 'unit_square.xdmf' into xdmf_ch
+    file "unit_square.h5" into h5_ch
+    file "unit_square.xdmf" into xdmf_ch
 
     """
     meshio convert $msh unit_square.xdmf
@@ -56,8 +56,8 @@ process solvePoisson {
     file mesh from xdmf_ch
 
     output:
-    file 'poisson.pvd' into pvd_ch
-    file 'poisson*.vtu' into vtu_ch
+    file "poisson.pvd" into pvd_ch
+    file "poisson*.vtu" into vtu_ch
 
     """
     python $fenics_code --mesh $mesh --degree ${params.degree} --outputfile poisson.pvd
@@ -65,7 +65,7 @@ process solvePoisson {
 }
 
 
-process makeContourplot {
+process makePlotOverLine {
 
     conda "../source/envs/postprocessing.yaml"
 
@@ -75,7 +75,7 @@ process makeContourplot {
     file pvd from pvd_ch
 
     output: 
-    file 'plotoverline.csv' into csv_ch
+    file "plotoverline.csv" into csv_ch
 
     """
     pvbatch $postproc $pvd plotoverline.csv
@@ -86,13 +86,14 @@ process makeContourplot {
 process compile {
 
     conda "../source/envs/postprocessing.yaml"
+    publishDir "$PWD"
 
     input:
     file tex_code from tex_ch
     file csv from csv_ch
 
     output:
-    file 'paper.pdf' 
+    file "paper.pdf" 
 
     """
     tectonic $tex_code


### PR DESCRIPTION
Hi @dglaeser ,
this PR adds some small changes and makes use of the [publishDir](https://www.nextflow.io/docs/latest/process.html?highlight=publishdir#publishdir) directive such that the final paper will be available in the working directory. By default this will create a symlink to the output file which is stored under `PWD/work/process_ID/some-hash/`.
To illustrate here are some commands and related output (`❯ ` is the shell prompt symbol):
```sh
❯ nextflow run simplecase.nf
N E X T F L O W  ~  version 21.04.0
Launching `simplecase.nf` [special_joliot] - revision: 872ff088b1
executor >  local (5)
[ce/755267] process > generateMesh (1)     [100%] 1 of 1 ✔
[35/b17a02] process > convertToXDMF (1)    [100%] 1 of 1 ✔
[42/9ba174] process > solvePoisson (1)     [100%] 1 of 1 ✔
[4b/8fbc19] process > makePlotOverLine (1) [100%] 1 of 1 ✔
[63/12dc10] process > compile (1)          [100%] 1 of 1 ✔
```
The `work` directory is created by default.
```sh
❯ tree work -L 2
work
├── 35
│   └── b17a028af3e0239057a1d155ceee00
├── 42
│   └── 9ba1745ff64e1ac4866bd85d2b4ad1
├── 4b
│   └── 8fbc193b04dd02c539e147dfc9f97e
├── 63
│   └── 12dc109a14ac6927bdafa1194b98aa
├── ce
│   └── 75526742ecc160706a530b1ceacd39
└── conda
    ├── postprocessing-7fc7267e126a749f6b9f352a86f2db7d
    ├── preprocessing-2205765b04b51c7abeaf3cdb6c0d65de
    └── processing-cd031d1c09c88b0367cfe85789066dcf

14 directories, 0 files
```
```sh
❯ ls work/63/12dc109a14ac6927bdafa1194b98aa
paper.pdf  paper.tex  plotoverline.csv
```
```sh
❯ ls -l
insgesamt 16
drwxrwxr-x 8 pdiercks pdiercks 4096 19. Jan 13:08 work
lrwxrwxrwx 1 pdiercks pdiercks  137 19. Jan 13:08 paper.pdf -> /home/pdiercks/Repos/bam/NFDI4IngScientificWorkflowRequirements/simple_use_case/nextflow/work/63/12dc109a14ac6927bdafa1194b98aa/paper.pdf
-rw-rw-r-- 1 pdiercks pdiercks  881  7. Jan 18:10 README.md
-rw-rw-r-- 1 pdiercks pdiercks 1926 19. Jan 12:56 simplecase.nf
```