### PR TITLE
CWL: demonstrate use of conda suggestions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,33 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  run-cwl-auto-conda:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout-repository
+        uses: actions/checkout@v2
+
+      - name: install-basic-deps
+        uses: ./.github/actions/install-basic-deps
+      - name: prepare-conda
+        uses: conda-incubator/setup-miniconda@v2
+  
+      - name: run-workflow
+        shell: bash -l {0}
+        run: |
+          sudo apt-get update && sudo apt-get install --no-install-recommends --yes python3-pip
+          python3 -m pip install cwltool[deps]
+          cd $GITHUB_WORKSPACE/simple_use_case/cwl
+          python3 -m cwltool --debug --beta-conda-dependencies wf_run_use_case.cwl
+
+      - name: upload-paper-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: paper
+          path: ./simple_use_case/cwl/paper.pdf
+          retention-days: 1
+          if-no-files-found: error
 
   run-nextflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: install-basic-deps
         uses: ./.github/actions/install-basic-deps
+
       - name: prepare-conda
         uses: conda-incubator/setup-miniconda@v2
   

--- a/simple_use_case/cwl/README.md
+++ b/simple_use_case/cwl/README.md
@@ -20,6 +20,13 @@ cwltool wf_run_use_case.cwl
 
 into your terminal.
 
+Or you can use the conda dependency feature of the CWL reference runner to obtain
+the dependencies dynamically:
+
+```sh
+cwltool --beta-conda-dependencies wf_run_use_case.cwl
+```
+
 Note that there exist tools to visualize, edit or create cwl workflows. For instance, you can
 visualize workflows contained in git repositories with [view.commonwl.org](https://view.commonwl.org/),
 or you can use the [Rabix Composer](https://github.com/rabix/composer) to compose workflows locally

--- a/simple_use_case/cwl/compile_paper.cwl
+++ b/simple_use_case/cwl/compile_paper.cwl
@@ -2,16 +2,21 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-doc: |
-  Create the paper as pdf, given the produced csv file
-baseCommand: ["tectonic"]
-arguments: ["$(inputs.texfile)"]
+doc: Create the paper as pdf, given the produced csv file
+baseCommand: tectonic
+arguments: [ $(inputs.texfile) ]
 requirements:
   InitialWorkDirRequirement:
       listing:
         - $(inputs.csvfile)
         - $(inputs.texfile)
         - $(inputs.macros)
+hints:
+  SoftwareRequirement:
+   packages:
+     tectonic:
+       version: [ 0.8.0=ha1fef3e_1, 0.8.0 ]
+       specs: [ https://anaconda.org/conda-forge/tectonic ]
 inputs:
   macros:
     type: File

--- a/simple_use_case/cwl/convert_msh_to_xdmf.cwl
+++ b/simple_use_case/cwl/convert_msh_to_xdmf.cwl
@@ -2,10 +2,19 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-doc: |
-  Convert the produced gmsh mesh to xdmf
-baseCommand: ["meshio", "convert"]
-arguments: ["$(inputs.inputmesh.path)", "mesh_converted.xdmf"]
+doc: Convert the produced gmsh mesh to xdmf
+
+hints:
+  SoftwareRequirement:
+   packages:
+     meshio:
+       version: [ 5.0.5=pyhd8ed1ab_0, 5.0.5 ]
+       specs:
+         - https://anaconda.org/conda-forge/meshio
+         - https://doi.org/10.5281/zenodo.1173115
+
+baseCommand: [ meshio, convert]
+arguments: [ $(inputs.inputmesh.path), mesh_converted.xdmf ]
 inputs:
   inputmesh:
     type: File

--- a/simple_use_case/cwl/make_gmsh_mesh.cwl
+++ b/simple_use_case/cwl/make_gmsh_mesh.cwl
@@ -2,9 +2,18 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-doc: |
-  Generate the computational mesh with gmsh
-baseCommand: ["gmsh"]
+doc: Generate the computational mesh with gmsh
+
+hints:
+  SoftwareRequirement:
+   packages:
+     gmsh:
+       version: [ 4.6.0=hd134328_0, 4.6.0 ]
+       specs:
+         - https://anaconda.org/conda-forge/gmsh
+         - https://identifiers.org/rrid/RRID:SCR_021226
+
+baseCommand: gmsh
 arguments: ["-setnumber", "domain_size", "$(inputs.domain_size)",
             "-2", "$(inputs.geofile.path)",
             "-o", "mesh.msh"]

--- a/simple_use_case/cwl/make_paraview_plot.cwl
+++ b/simple_use_case/cwl/make_paraview_plot.cwl
@@ -2,10 +2,20 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-doc: |
-  Create plot-over-line data with paraview`s pvbatch
-baseCommand: ["pvbatch"]
+doc: Create plot-over-line data with paraview`s pvbatch
+baseCommand: [pvbatch]
 arguments: ["$(inputs.script)", "$(inputs.pvdfile.path)", "plotoverline.csv"]
+
+hints:
+  SoftwareRequirement:
+   packages:
+     paraview:
+       version: [ 5.9.1=hfc1cbd4_3_egl, 5.9.1 ]
+       specs:
+         - https://anaconda.org/conda-forge/paraview
+         - https://identifiers.org/rrid/RRID:SCR_002516
+         - https://bio.tools/paraview
+
 requirements:
   InitialWorkDirRequirement:
       listing:

--- a/simple_use_case/cwl/prepare_paper_macros.cwl
+++ b/simple_use_case/cwl/prepare_paper_macros.cwl
@@ -2,8 +2,7 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-doc: |
-  Update the macros of the paper with values from this run
+doc: Update the macros of the paper with values from this run
 baseCommand: ["python3"]
 arguments: ["$(inputs.substitution_script)",
             "--domain-size", "$(inputs.domain_size)",

--- a/simple_use_case/cwl/run_dolfin.cwl
+++ b/simple_use_case/cwl/run_dolfin.cwl
@@ -2,13 +2,21 @@
 
 cwlVersion: v1.0
 class: CommandLineTool
-doc: |
-  Run the poisson solver in dolfin
-baseCommand: ["python3"]
+doc: Run the poisson solver in dolfin
+baseCommand: python3
 arguments: ["$(inputs.script)", "--mesh", "$(inputs.xdmfmeshfile.path)",
                                 "--degree", "2",
                                 "--output", "result.pvd"]
 stdout: output.txt
+hints:
+  SoftwareRequirement:
+   packages:
+     fenics:
+       version: [ 2019.1.0=py39hf3d152e_26, 2019.1.0 ]
+       specs:
+         - https://anaconda.org/conda-forge/fenics
+         - https://bio.tools/fenics
+
 requirements:
   InlineJavascriptRequirement: {}
   InitialWorkDirRequirement:


### PR DESCRIPTION
Allows each step to use a different conda environment and the selection
of conda packages that are not co-installable.

I can also send a PR to replace `prepare_paper_macros.cwl` with an inline file creation as part of `compile_paper.cwl`, if desired