### PR TITLE
[workflows][main] set channel priority to strict for snakemake workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,7 @@ jobs:
           miniforge-version: latest
           activate-environment: simple_use_case
           channels: conda-forge,bioconda
+          channel-priority: strict
 
       - name: run-workflow
         shell: bash -l {0}


### PR DESCRIPTION
This PR sets the channel priority to strict for the snakemake workflow in the github actions.

Info:
```
~ via 🅒 base ❯ conda config --describe channel_priority
# # channel_priority (ChannelPriority)
# #   Accepts values of 'strict', 'flexible', and 'disabled'. The default
# #   value is 'flexible'. With strict channel priority, packages in lower
# #   priority channels are not considered if a package with the same name
# #   appears in a higher priority channel. With flexible channel priority,
# #   the solver may reach into lower priority channels to fulfill
# #   dependencies, rather than raising an unsatisfiable error. With channel
# #   priority disabled, package version takes precedence, and the
# #   configured priority of channels is used only to break ties. In
# #   previous versions of conda, this parameter was configured as either
# #   True or False. True is now an alias to 'flexible'.
# #
# channel_priority: flexible
```