### PR TITLE
Feature/snakemake fmt

### DIFF
--- a/simple_use_case/snakemake/Snakefile
+++ b/simple_use_case/snakemake/Snakefile
@@ -1,7 +1,7 @@
 configfile: "./config.yaml"
 
 
-# NOTE 
+# NOTE
 # $ snakemake --use-conda --cores 1 --config domain_size=4.0
 # does not re-execute the job generated from rule 'generate_mesh'
 # if it was executed before with e.g. the default value 2.0
@@ -9,7 +9,7 @@ configfile: "./config.yaml"
 # $ snakemake -R somerule
 rule generate_mesh:
     input:
-        "../source/unit_square.geo"
+        "../source/unit_square.geo",
     output:
         "preprocessing/square.msh",
     conda:
@@ -19,23 +19,23 @@ rule generate_mesh:
 
 
 rule convert_to_xdmf:
-	input:
-		rules.generate_mesh.output
-	output:
-		"preprocessing/square.xdmf"
-	conda:
-		"../source/envs/preprocessing.yaml"
-	shell:
-		"meshio convert {input} {output}"
+    input:
+        rules.generate_mesh.output,
+    output:
+        "preprocessing/square.xdmf",
+    conda:
+        "../source/envs/preprocessing.yaml"
+    shell:
+        "meshio convert {input} {output}"
 
 
 rule poisson:
     input:
         py="../source/poisson.py",
-        xdmf=rules.convert_to_xdmf.output
+        xdmf=rules.convert_to_xdmf.output,
     output:
         pvd="processing/poisson.pvd",
-        txt="processing/numdofs.txt"
+        txt="processing/numdofs.txt",
     conda:
         "../source/envs/processing.yaml"
     shell:
@@ -45,9 +45,9 @@ rule poisson:
 rule plot_over_line:
     input:
         py="../source/postprocessing.py",
-        pvd=rules.poisson.output.pvd
+        pvd=rules.poisson.output.pvd,
     output:
-        "postprocessing/plotoverline.csv"
+        "postprocessing/plotoverline.csv",
     conda:
         "../source/envs/postprocessing.yaml"
     shell:
@@ -59,26 +59,29 @@ rule substitute_macros:
         py="../source/prepare_paper_macros.py",
         template="../source/macros.tex.template",
         data=rules.plot_over_line.output,
-        ndofs=rules.poisson.output.txt
+        ndofs=rules.poisson.output.txt,
     output:
-        "macros.tex"
+        "macros.tex",
     run:
         with open(input.ndofs, "r") as instream:
             ndofs = int(instream.read())
-        shell("python {input.py} --macro-template-file {input.template} \
-                --plot-data-path {input.data} \
-                --domain-size {config[domain_size]} \
-                --num-dofs %s \
-                --output-macro-file {output[0]}" % (ndofs))
+        shell(
+            "python {input.py} --macro-template-file {input.template} \
+        --plot-data-path {input.data} \
+        --domain-size {config[domain_size]} \
+        --num-dofs %s \
+        --output-macro-file {output[0]}"
+            % (ndofs)
+        )
 
 
 rule compile_paper:
     input:
         paper="../source/paper.tex",
-        macros=rules.substitute_macros.output
+        macros=rules.substitute_macros.output,
     output:
         tex="paper.tex",
-        pdf="paper.pdf"
+        pdf="paper.pdf",
     conda:
         "../source/envs/postprocessing.yaml"
     shell:

--- a/simple_use_case/snakemake/Snakefile
+++ b/simple_use_case/snakemake/Snakefile
@@ -14,8 +14,10 @@ rule generate_mesh:
         "preprocessing/square.msh",
     conda:
         "../source/envs/preprocessing.yaml"
+    log:
+        "logs/gmsh.log",
     shell:
-        "gmsh -2 -setnumber domain_size {config[domain_size]} {input} -o {output}"
+        "gmsh -2 -setnumber domain_size {config[domain_size]} {input} -o {output} > {log} 2>&1"
 
 
 rule convert_to_xdmf:
@@ -25,8 +27,10 @@ rule convert_to_xdmf:
         "preprocessing/square.xdmf",
     conda:
         "../source/envs/preprocessing.yaml"
+    log:
+        "logs/meshio.log",
     shell:
-        "meshio convert {input} {output}"
+        "meshio convert {input} {output} > {log} 2>&1"
 
 
 rule poisson:
@@ -38,8 +42,10 @@ rule poisson:
         txt="processing/numdofs.txt",
     conda:
         "../source/envs/processing.yaml"
+    log:
+        "logs/fenics.log",
     shell:
-        "python {input.py} --mesh {input.xdmf} --degree 2 --outputfile {output.pvd} --num-dofs {output.txt}"
+        "python {input.py} --mesh {input.xdmf} --degree 2 --outputfile {output.pvd} --num-dofs {output.txt} > {log} 2>&1"
 
 
 rule plot_over_line:
@@ -50,8 +56,10 @@ rule plot_over_line:
         "postprocessing/plotoverline.csv",
     conda:
         "../source/envs/postprocessing.yaml"
+    log:
+        "logs/paraview.log",
     shell:
-        "pvbatch {input.py} {input.pvd} {output}"
+        "pvbatch {input.py} {input.pvd} {output} > {log} 2>&1"
 
 
 rule substitute_macros:
@@ -62,6 +70,8 @@ rule substitute_macros:
         ndofs=rules.poisson.output.txt,
     output:
         "macros.tex",
+    log:
+        "logs/macros.log",
     run:
         with open(input.ndofs, "r") as instream:
             ndofs = int(instream.read())
@@ -84,5 +94,7 @@ rule compile_paper:
         pdf="paper.pdf",
     conda:
         "../source/envs/postprocessing.yaml"
+    log:
+        "logs/tectonic.log",
     shell:
-        "cp {input.paper} {output.tex} && tectonic {output.tex}"
+        "cp {input.paper} {output.tex} && tectonic {output.tex} > {log} 2>&1"


### PR DESCRIPTION
Hi, this PR formats the `Snakefile` using `snakefmt` (snakemakes formatter) and also incorporates suggestions made by `snakemake --lint`. The linter mostly complained about the `log` directive not being used, which was then added. 

Running `snakemake --lint` should now give the following output:
```
Lints for rule generate_mesh (line 11, /home/pdiercks/repos/nfdi4ing/scientific_wf_reqs/simple_use_case/snakemake/Snakefile):
    * Shell command directly uses variable config from outside of the rule:
      It is recommended to pass all files as input and output, and non-file parameters via the params directive. Otherwise, provenance
      tracking is less accurate.
      Also see:
      https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#non-file-parameters-for-rules

Lints for rule substitute_macros (line 126, /home/pdiercks/repos/nfdi4ing/scientific_wf_reqs/simple_use_case/snakemake/Snakefile):
    * Migrate long run directives into scripts or notebooks:
      Long run directives hamper workflow readability. Use the script or notebook direcive instead. Note that the script or notebook
      directive does not involve boilerplate. Similar to run, you will have direct access to params, input, output, and wildcards.Only
      use the run direcive for a handful of lines.
      Also see:
      https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#external-scripts
      https://snakemake.readthedocs.io/en/latest/snakefiles/rules.html#jupyter-notebook-integration
```

I did not address the first point for rule generate_mesh since `params` does not seem to be able to use values of the config file and using the config file was the only way to be able to set `domain_size` via the CLI. 
The second point regarding substitute_macros: it would be more natural to use the script directive, but since we use the python script `prepare_paper_macros.py` in each of the workflow implementations, using a script directive everywhere would duplicate the code. Hence, I did not address this point either.