### PR TITLE
Add pyiron based example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,3 +301,35 @@ jobs:
       with:
         name: paper
         path: exemplary_workflow/gwl/paper.pdf
+
+  run-pyiron:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout-repository
+        uses: actions/checkout@v2
+
+      - name: install-basic-deps
+        uses: ./.github/actions/install-basic-deps
+
+      - name: setup-conda-environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-version: latest
+          activate-environment: exemplary_workflow
+          channels: conda-forge
+          channel-priority: strict
+
+      - name: run-workflow
+        shell: bash -l {0}
+        run: |
+          conda install pyiron_base=0.7.11
+          cd $GITHUB_WORKSPACE/exemplary_workflow/pyiron
+          python workflow.py
+      - name: upload-paper-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: paper
+          path: ./exemplary_workflow/pyiron/workflow/tectonic_hdf5/tectonic/paper.pdf
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,7 +323,7 @@ jobs:
       - name: run-workflow
         shell: bash -l {0}
         run: |
-          conda install pyiron_base=0.7.11
+          conda install conda_subprocess=0.0.1 pyiron_base=0.7.11
           cd $GITHUB_WORKSPACE/exemplary_workflow/pyiron
           python workflow.py
       - name: upload-paper-artifact

--- a/exemplary_workflow/pyiron/README.md
+++ b/exemplary_workflow/pyiron/README.md
@@ -7,7 +7,7 @@ The recommended way of installing `pyiron_base` is via conda, because it also en
 
 You can then install `pyiron_base` with
 ```sh
-mamba env create -c conda-forge -n pyiron_base pyiron_base=0.7.11 conda_subprocess=0.0.1
+mamba create -c conda-forge -n pyiron_base pyiron_base=0.7.11 conda_subprocess=0.0.1
 ```
 
 ## Running the exemplary workflow

--- a/exemplary_workflow/pyiron/README.md
+++ b/exemplary_workflow/pyiron/README.md
@@ -1,0 +1,21 @@
+# pyiron
+This directory contains an implementation of the exemplary workflow with [pyiron](https://pyiron.org/) or more specifically the [pyiron_base](https://pyiron-base.readthedocs.io) workflow manager.
+
+## Installation
+For more detailed information we refer to the official [documentation](https://pyiron-base.readthedocs.io/en/latest/installation.html).
+The recommended way of installing `pyiron_base` is via conda, because it also enables `pyiron_base` to handle software dependencies of your workflow using the [conda_subprocess](https://github.com/pyiron/conda_subprocess) package.
+
+You can then install `pyiron_base` with
+```sh
+mamba env create -c conda-forge -n pyiron_base pyiron_base=0.7.11 conda_subprocess=0.0.1
+```
+
+## Running the exemplary workflow
+The workflow can be run with
+```sh
+python workflow.py
+```
+The final output `paper.pdf` created using the `tectonic` package is then stored in:
+```sh
+./workflow/tectonic_hdf5/tectonic/paper.pdf
+```

--- a/exemplary_workflow/pyiron/README.md
+++ b/exemplary_workflow/pyiron/README.md
@@ -15,7 +15,8 @@ The workflow can be run with
 ```sh
 python workflow.py
 ```
-The final output `paper.pdf` created using the `tectonic` package is then stored in:
+The final output `paper.pdf` created using the `tectonic` package is then stored in the working direcrtory of last workflow step:
 ```sh
 ./workflow/tectonic_hdf5/tectonic/paper.pdf
 ```
+This is a general feature of the `pyiron_base` workflow manager, each step of the workflow - called job - is executed in a separate working directory. 

--- a/exemplary_workflow/pyiron/workflow.py
+++ b/exemplary_workflow/pyiron/workflow.py
@@ -1,6 +1,8 @@
 import os
 from pyiron_base import Project
 
+# input parameter 
+domain_size = 2.0
 
 # create pyiron project 
 pr = Project("workflow")
@@ -16,7 +18,7 @@ for k, v in {
 
 # Preprocessing
 ## generate mesh
-def write_input(input_dict, working_directory):
+def write_input_generate_mesh(input_dict, working_directory):
     script_name = os.path.join(working_directory, "gmsh.sh")
     with open(script_name, "w") as f:
         f.writelines("gmsh -2 -setnumber domain_size " + str(input_dict["domain_size"]) + " unit_square.geo -o square.msh")
@@ -25,8 +27,8 @@ def write_input(input_dict, working_directory):
 gmsh = pr.wrap_executable(
     job_name="gmsh",
     executable_str="./gmsh.sh",
-    write_input_funct=write_input,
-    input_dict={"domain_size": 2.0},
+    write_input_funct=write_input_generate_mesh,
+    input_dict={"domain_size": domain_size},
     conda_environment_path=pr.conda_environment.preprocessing,
     input_file_lst=["../source/unit_square.geo"],
     execute_job=True,
@@ -44,14 +46,14 @@ meshio = pr.wrap_executable(
 
 # Processing
 ## poisson
-def collect_output(working_directory):
+def collect_output_poisson(working_directory):
     with open(os.path.join(working_directory, "numdofs.txt"), "r") as f:
         return {"numdofs": int(f.read())}
 
 poisson = pr.wrap_executable(
     job_name="poisson",
     executable_str="python poisson.py --mesh square.xdmf --degree 2 --outputfile poisson.pvd --num-dofs numdofs.txt",
-    collect_output_funct=collect_output,
+    collect_output_funct=collect_output_poisson,
     conda_environment_path=pr.conda_environment.processing,
     input_file_lst=["../source/poisson.py", meshio.files.square_xdmf, meshio.files.square_h5],
     execute_job=True,
@@ -69,7 +71,7 @@ pvbatch = pr.wrap_executable(
 )
 
 ## substitute macros
-def write_input(input_dict, working_directory):
+def write_input_macros(input_dict, working_directory):
     script_name = os.path.join(working_directory, "macros.sh")
     with open(script_name, "w") as f:
         f.writelines("python prepare_paper_macros.py --macro-template-file macros.tex.template --plot-data-path plotoverline.csv --domain-size " + str(input_dict["domain_size"]) + " --num-dofs " + str(input_dict["numdofs"]) + " --output-macro-file macros.tex")
@@ -78,8 +80,11 @@ def write_input(input_dict, working_directory):
 macros = pr.wrap_executable(
     job_name="macros",
     executable_str="./macros.sh",
-    write_input_funct=write_input,
-    input_dict={"domain_size": 2.0, "numdofs": 100},
+    write_input_funct=write_input_macros,
+    input_dict={
+        "domain_size": domain_size, 
+        "numdofs": poisson.output["numdofs"],
+    },
     conda_environment_path=pr.conda_environment.postprocessing,
     input_file_lst=["../source/macros.tex.template", "../source/prepare_paper_macros.py", pvbatch.files.plotoverline_csv],
     execute_job=True,

--- a/exemplary_workflow/pyiron/workflow.py
+++ b/exemplary_workflow/pyiron/workflow.py
@@ -1,0 +1,99 @@
+import os
+from pyiron_base import Project
+
+
+# create pyiron project 
+pr = Project("workflow")
+
+# create conda environments for the proprocessing, processing and postprocessing stage 
+for k, v in {
+    "preprocessing": "../source/envs/preprocessing.yaml",
+    "processing": "../source/envs/processing.yaml",
+    "postprocessing": "../source/envs/postprocessing.yaml"
+}.items():
+    pr.conda_environment.create(env_name=k, env_file=v)
+
+
+# Preprocessing
+
+## generate mesh
+def write_input(input_dict, working_directory):
+    script_name = os.path.join(working_directory, "gmsh.sh")
+    with open(script_name, "w") as f:
+        f.writelines("gmsh -2 -setnumber domain_size " + str(input_dict["domain_size"]) + " unit_square.geo -o square.msh")
+    os.chmod(script_name, 0o744)
+
+gmsh = pr.wrap_executable(
+    job_name="gmsh",
+    executable_str="./gmsh.sh",
+    write_input_funct=write_input,
+    input_dict={"domain_size": 2.0},
+    conda_environment_path=pr.conda_environment.preprocessing,
+    input_file_lst=["source/unit_square.geo"],
+    execute_job=True,
+)
+
+
+## convert mesh to xdmf
+meshio = pr.wrap_executable(
+    job_name="meshio",
+    executable_str="meshio convert square.msh square.xdmf",
+    conda_environment_path=pr.conda_environment.preprocessing,
+    input_file_lst=[gmsh.files.square_msh],
+    execute_job=True,
+)
+
+
+# Processing
+## poisson
+def collect_output(working_directory):
+    with open(os.path.join(working_directory, "numdofs.txt"), "r") as f:
+        return {"numdofs": int(f.read())}
+
+poisson = pr.wrap_executable(
+    job_name="poisson",
+    executable_str="python poisson.py --mesh square.xdmf --degree 2 --outputfile poisson.pvd --num-dofs numdofs.txt",
+    collect_output_funct=collect_output,
+    conda_environment_path=pr.conda_environment.processing,
+    input_file_lst=["source/poisson.py", meshio.files.square_xdmf, meshio.files.square_h5],
+    execute_job=True,
+)
+
+
+# Postprocessing
+## plot over line
+pvbatch = pr.wrap_executable(
+    job_name="pvbatch",
+    executable_str="pvbatch postprocessing.py poisson.pvd plotoverline.csv",
+    conda_environment_path=pr.conda_environment.postprocessing,
+    input_file_lst=["source/postprocessing.py", poisson.files.poisson_pvd, poisson.files.poisson000000_vtu],
+    execute_job=True,
+)
+
+## substitute macros
+def write_input(input_dict, working_directory):
+    script_name = os.path.join(working_directory, "macros.sh")
+    with open(script_name, "w") as f:
+        f.writelines("python prepare_paper_macros.py --macro-template-file macros.tex.template --plot-data-path plotoverline.csv --domain-size " + str(input_dict["domain_size"]) + " --num-dofs " + str(input_dict["numdofs"]) + " --output-macro-file macros.tex")
+    os.chmod(script_name, 0o744)
+
+macros = pr.wrap_executable(
+    job_name="macros",
+    executable_str="./macros.sh",
+    write_input_funct=write_input,
+    input_dict={"domain_size": 2.0, "numdofs": 100},
+    conda_environment_path=pr.conda_environment.postprocessing,
+    input_file_lst=["source/macros.tex.template", "source/prepare_paper_macros.py", pvbatch.files.plotoverline_csv],
+    execute_job=True,
+)
+
+## compile paper
+tectonic = pr.wrap_executable(
+    job_name="tectonic",
+    executable_str="tectonic paper.tex",
+    conda_environment_path=pr.conda_environment.postprocessing,
+    input_file_lst=["source/paper.tex", macros.files.macros_tex, pvbatch.files.plotoverline_csv],
+    execute_job=True,
+)
+
+

--- a/exemplary_workflow/pyiron/workflow.py
+++ b/exemplary_workflow/pyiron/workflow.py
@@ -18,17 +18,9 @@ for k, v in {
 
 # Preprocessing
 ## generate mesh
-def write_input_generate_mesh(input_dict, working_directory):
-    script_name = os.path.join(working_directory, "gmsh.sh")
-    with open(script_name, "w") as f:
-        f.writelines("gmsh -2 -setnumber domain_size " + str(input_dict["domain_size"]) + " unit_square.geo -o square.msh")
-    os.chmod(script_name, 0o744)
-
 gmsh = pr.wrap_executable(
     job_name="gmsh",
-    executable_str="./gmsh.sh",
-    write_input_funct=write_input_generate_mesh,
-    input_dict={"domain_size": domain_size},
+    executable_str=f"gmsh -2 -setnumber domain_size {domain_size} unit_square.geo -o square.msh",
     conda_environment_path=pr.conda_environment.preprocessing,
     input_file_lst=["../source/unit_square.geo"],
     execute_job=True,
@@ -71,20 +63,9 @@ pvbatch = pr.wrap_executable(
 )
 
 ## substitute macros
-def write_input_macros(input_dict, working_directory):
-    script_name = os.path.join(working_directory, "macros.sh")
-    with open(script_name, "w") as f:
-        f.writelines("python prepare_paper_macros.py --macro-template-file macros.tex.template --plot-data-path plotoverline.csv --domain-size " + str(input_dict["domain_size"]) + " --num-dofs " + str(input_dict["numdofs"]) + " --output-macro-file macros.tex")
-    os.chmod(script_name, 0o744)
-
 macros = pr.wrap_executable(
     job_name="macros",
-    executable_str="./macros.sh",
-    write_input_funct=write_input_macros,
-    input_dict={
-        "domain_size": domain_size, 
-        "numdofs": poisson.output["numdofs"],
-    },
+    executable_str=f"python prepare_paper_macros.py --macro-template-file macros.tex.template --plot-data-path plotoverline.csv --domain-size {domain_size} --num-dofs {poisson.output['numdofs']} --output-macro-file macros.tex",
     conda_environment_path=pr.conda_environment.postprocessing,
     input_file_lst=["../source/macros.tex.template", "../source/prepare_paper_macros.py", pvbatch.files.plotoverline_csv],
     execute_job=True,

--- a/exemplary_workflow/pyiron/workflow.py
+++ b/exemplary_workflow/pyiron/workflow.py
@@ -28,7 +28,7 @@ gmsh = pr.wrap_executable(
     write_input_funct=write_input,
     input_dict={"domain_size": 2.0},
     conda_environment_path=pr.conda_environment.preprocessing,
-    input_file_lst=["source/unit_square.geo"],
+    input_file_lst=["../source/unit_square.geo"],
     execute_job=True,
 )
 
@@ -53,7 +53,7 @@ poisson = pr.wrap_executable(
     executable_str="python poisson.py --mesh square.xdmf --degree 2 --outputfile poisson.pvd --num-dofs numdofs.txt",
     collect_output_funct=collect_output,
     conda_environment_path=pr.conda_environment.processing,
-    input_file_lst=["source/poisson.py", meshio.files.square_xdmf, meshio.files.square_h5],
+    input_file_lst=["../source/poisson.py", meshio.files.square_xdmf, meshio.files.square_h5],
     execute_job=True,
 )
 
@@ -64,7 +64,7 @@ pvbatch = pr.wrap_executable(
     job_name="pvbatch",
     executable_str="pvbatch postprocessing.py poisson.pvd plotoverline.csv",
     conda_environment_path=pr.conda_environment.postprocessing,
-    input_file_lst=["source/postprocessing.py", poisson.files.poisson_pvd, poisson.files.poisson000000_vtu],
+    input_file_lst=["../source/postprocessing.py", poisson.files.poisson_pvd, poisson.files.poisson000000_vtu],
     execute_job=True,
 )
 
@@ -81,7 +81,7 @@ macros = pr.wrap_executable(
     write_input_funct=write_input,
     input_dict={"domain_size": 2.0, "numdofs": 100},
     conda_environment_path=pr.conda_environment.postprocessing,
-    input_file_lst=["source/macros.tex.template", "source/prepare_paper_macros.py", pvbatch.files.plotoverline_csv],
+    input_file_lst=["../source/macros.tex.template", "../source/prepare_paper_macros.py", pvbatch.files.plotoverline_csv],
     execute_job=True,
 )
 
@@ -90,8 +90,6 @@ tectonic = pr.wrap_executable(
     job_name="tectonic",
     executable_str="tectonic paper.tex",
     conda_environment_path=pr.conda_environment.postprocessing,
-    input_file_lst=["source/paper.tex", macros.files.macros_tex, pvbatch.files.plotoverline_csv],
+    input_file_lst=["../source/paper.tex", macros.files.macros_tex, pvbatch.files.plotoverline_csv],
     execute_job=True,
 )
-
-

--- a/exemplary_workflow/pyiron/workflow.py
+++ b/exemplary_workflow/pyiron/workflow.py
@@ -15,7 +15,6 @@ for k, v in {
 
 
 # Preprocessing
-
 ## generate mesh
 def write_input(input_dict, working_directory):
     script_name = os.path.join(working_directory, "gmsh.sh")
@@ -32,7 +31,6 @@ gmsh = pr.wrap_executable(
     input_file_lst=["source/unit_square.geo"],
     execute_job=True,
 )
-
 
 ## convert mesh to xdmf
 meshio = pr.wrap_executable(


### PR DESCRIPTION
This pull requests implements the example workflow using the [pyiron_base](https://pyiron-base.readthedocs.io) workflow manager which is developed as part of the [pyiron](https://pyiron.org) project. The workflow in the `workflow.py` file can be executed using:
```sh
python workflow.py
```

In addition, the pull request also adds the corresponding Github action and a short Readme to explain the usage of the example. 